### PR TITLE
selectAllFields changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,24 @@ List<Account> accounts = new Query('Account').run();
 
 ### Select all fields
 
-This will query all Accounts from the database, selecting all fields which
-the user has access privilege on.
+This will query all Accounts from the database, selecting all fields.
 
 ```javascript
 List<Account> accounts =
     new Query('Account').
     selectAllFields().
+    run();
+```
+
+### Select all user readable fields
+
+This will query all Accounts from the database, selecting all fields which
+the user has read access on.
+
+```javascript
+List<Account> accounts =
+    new Query('Account').
+    selectReadableFields().
     run();
 ```
 
@@ -170,6 +181,15 @@ List<Contact> contacts =
     run();
 ```
 
+This will select all user readable fields from the parent object Account.
+
+```javascript
+List<Contact> contacts =
+    new Query('Contact').
+    selectReadableFields('Account').
+    run();
+```
+
 ### Query with simple conditions
 
 This will query all the accounts whose 'FirstName' is 'Sam' and 'LastName' is
@@ -231,7 +251,7 @@ List<QuickText> result = new Query('QuickText').
     run();
 ```
 
-In contrast, this example is a condition that includes any of the two values: 
+In contrast, this example is a condition that includes any of the two values:
 
 ```javascript
 List<QuickText> result = new Query('QuickText').

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -228,11 +228,19 @@ public class Query {
     }
 
     /*
-     * Select all user accessible fields
+     * Select all fields of the object
      */
     public Query selectAllFields() {
-        FieldSetting config = new FieldSetting();
-        this.fieldSetting = config;
+        this.isSystemContext = true;
+        initFieldSetting();
+        return this;
+    }
+
+    /*
+     * Select all user accessible fields
+     */
+    public Query selectReadableFields() {
+        initFieldSetting();
         return this;
     }
 
@@ -257,9 +265,17 @@ public class Query {
     }
 
     /*
-     * Select all user accessible fields from a parent field
+     * Select all fields from a parent field
      */
     public Query selectAllFields(String parentField) {
+      this.isSystemContext = true;
+        return selectParentFields(parentField);
+    }
+
+    /*
+     * Select all user accessible fields from a parent field
+     */
+    public Query selectReadableFields(String parentField) {
         return selectParentFields(parentField);
     }
 
@@ -1595,6 +1611,7 @@ public class Query {
     private Integer resultOffset = -1;
     private Map<String, Query> childQuerys = new Map<String, Query>();
     private Boolean addAllRows = false;
+    private Boolean isSystemContext = false;
 
     public class FieldSetting {
         public Boolean isAccessible = true;
@@ -1761,6 +1778,9 @@ public class Query {
             if (config.isWriteRequiresMasterRead) {
                 flag = flag && fieldMap.get(fieldName).getDescribe().isWriteRequiresMasterRead();
             }
+            if (this.isSystemContext) {
+                flag = this.isSystemContext;
+            }
             if (flag) {
                 fields.add(fieldName.toLowerCase());
             }
@@ -1881,8 +1901,11 @@ public class Query {
                 getParentObjectType(objectType, parentName).getDescribe().fields.getMap();
 
         // Add the field if it is accessible by the user
+        // or query has to run in system context
         for (String fieldName : fieldMap.keySet()) {
-            if (fieldMap.get(fieldName).getDescribe().isAccessible()) {
+            if (this.isSystemContext ||
+                fieldMap.get(fieldName).getDescribe().isAccessible())
+            {
                 fields.add((appendNamespaceToField(parentName) + '.' + fieldName).
                         toLowerCase());
             }
@@ -2436,6 +2459,11 @@ public class Query {
         } else {
             return '';
         }
+    }
+
+    private void initFieldSetting(){
+        FieldSetting config = new FieldSetting();
+        this.fieldSetting = config;
     }
 
     private class QueryException extends Exception {

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -231,8 +231,8 @@ public class Query {
      * Select all fields of the object
      */
     public Query selectAllFields() {
-        this.isSystemContext = true;
-        initFieldSetting();
+        this.fieldSetting = initFieldSetting();
+        this.fieldSetting.isSystemContext = true;
         return this;
     }
 
@@ -240,7 +240,7 @@ public class Query {
      * Select all user accessible fields
      */
     public Query selectReadableFields() {
-        initFieldSetting();
+        this.fieldSetting = initFieldSetting();
         return this;
     }
 
@@ -248,9 +248,8 @@ public class Query {
      * Select all user editable fields
      */
     public Query selectEditableFields() {
-        FieldSetting config = new FieldSetting();
-        config.isUpdateable = true;
-        this.fieldSetting = config;
+        this.fieldSetting = initFieldSetting();
+        this.fieldSetting.isUpdateable = true;
         return this;
     }
 
@@ -258,9 +257,8 @@ public class Query {
      * Select all user creatable fields
      */
     public Query selectCreatableFields() {
-        FieldSetting config = new FieldSetting();
-        config.isCreateable = true;
-        this.fieldSetting = config;
+        this.fieldSetting = initFieldSetting();
+        this.fieldSetting.isCreateable = true;
         return this;
     }
 
@@ -268,7 +266,8 @@ public class Query {
      * Select all fields from a parent field
      */
     public Query selectAllFields(String parentField) {
-      this.isSystemContext = true;
+        this.parentFieldSetting = initParentFieldSetting();
+        this.parentFieldSetting.isSystemContext = true;
         return selectParentFields(parentField);
     }
 
@@ -276,6 +275,7 @@ public class Query {
      * Select all user accessible fields from a parent field
      */
     public Query selectReadableFields(String parentField) {
+        this.ParentFieldSetting = initParentFieldSetting();
         return selectParentFields(parentField);
     }
 
@@ -1578,6 +1578,7 @@ public class Query {
     private Set<String> fields = new Set<String>();
     private Set<String> parentReferences = new Set<String>();
     private FieldSetting fieldSetting;
+    private ParentFieldSetting parentFieldSetting;
 
     private List<String> conditions = new List<String>();
     private static final Integer maxArgSize = 20;
@@ -1611,7 +1612,6 @@ public class Query {
     private Integer resultOffset = -1;
     private Map<String, Query> childQuerys = new Map<String, Query>();
     private Boolean addAllRows = false;
-    private Boolean isSystemContext = false;
 
     public class FieldSetting {
         public Boolean isAccessible = true;
@@ -1640,6 +1640,11 @@ public class Query {
         public Boolean isUnique = false;
         public Boolean isUpdateable = false;
         public Boolean isWriteRequiresMasterRead = false;
+        public Boolean isSystemContext = false;
+    }
+
+    public class ParentFieldSetting {
+        public Boolean isSystemContext = false;
     }
 
     private List<OrderTuple> orderList = new List<OrderTuple>();
@@ -1778,8 +1783,8 @@ public class Query {
             if (config.isWriteRequiresMasterRead) {
                 flag = flag && fieldMap.get(fieldName).getDescribe().isWriteRequiresMasterRead();
             }
-            if (this.isSystemContext) {
-                flag = this.isSystemContext;
+            if (config.isSystemContext) {
+                flag = config.isSystemContext;
             }
             if (flag) {
                 fields.add(fieldName.toLowerCase());
@@ -1903,7 +1908,7 @@ public class Query {
         // Add the field if it is accessible by the user
         // or query has to run in system context
         for (String fieldName : fieldMap.keySet()) {
-            if (this.isSystemContext ||
+            if (isSelectAllParentFieldsSet() ||
                 fieldMap.get(fieldName).getDescribe().isAccessible())
             {
                 fields.add((appendNamespaceToField(parentName) + '.' + fieldName).
@@ -1911,6 +1916,11 @@ public class Query {
             }
         }
         return this;
+    }
+
+    private Boolean isSelectAllParentFieldsSet(){
+        return parentFieldSetting != null &&
+            parentFieldSetting.isSystemContext;
     }
 
     private void saveConditions(List<Object> args) {
@@ -2461,9 +2471,14 @@ public class Query {
         }
     }
 
-    private void initFieldSetting(){
+    private FieldSetting initFieldSetting(){
         FieldSetting config = new FieldSetting();
-        this.fieldSetting = config;
+        return config;
+    }
+
+    private ParentFieldSetting initParentFieldSetting(){
+        ParentFieldSetting config = new ParentFieldSetting();
+        return config;
     }
 
     private class QueryException extends Exception {

--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -42,6 +42,30 @@ public class QueryTest {
     }
 
     @isTest
+    static void selectReadableFieldsTest() {
+        createData();
+        List<Account> accounts;
+
+        accounts = new Query('Account').
+            selectReadableFields().
+            run();
+
+        assertAccount(accounts.get(0));
+
+        accounts = new Query(Account.getSObjectType()).
+            selectEditableFields().
+            run();
+
+        assertAccount(accounts.get(0));
+
+        accounts = new Query(Account.getSObjectType()).
+            selectCreatableFields().
+            run();
+
+        assertAccount(accounts.get(0));
+    }
+
+    @isTest
     static void selectAllFieldsTest() {
         createData();
         List<Account> accounts;
@@ -161,7 +185,33 @@ public class QueryTest {
     }
 
     @isTest
-    static void parentFieldsTest() {
+    static void readableParentFieldsTest() {
+        createData();
+
+        List<Opportunity> opportunities;
+
+        opportunities = new Query('Opportunity').
+            selectReadableFields().
+            selectReadableFields('CreatedBy').
+            selectReadableFields('Account.LastModifiedBy').
+            selectFields('Account.CreatedBy.FirstName').
+            selectFields('LastModifiedBy.FirstName, LastModifiedBy.LastName').
+            selectFields(new List<String>{'Owner.FirstName', 'Owner.LastName'}).
+            run();
+
+        assertOpportunity(opportunities.get(0));
+
+        System.assertNotEquals(opportunities.get(0).CreatedBy.FirstName, null);
+        System.assertNotEquals(opportunities.get(0).Account.CreatedBy.FirstName, null);
+        System.assertNotEquals(opportunities.get(0).Account.LastModifiedBy.FirstName, null);
+        System.assertNotEquals(opportunities.get(0).LastModifiedBy.FirstName, null);
+        System.assertNotEquals(opportunities.get(0).LastModifiedBy.LastName, null);
+        System.assertNotEquals(opportunities.get(0).Owner.FirstName, null);
+        System.assertNotEquals(opportunities.get(0).Owner.LastName, null);
+    }
+
+    @isTest
+    static void allParentFieldsTest() {
         createData();
 
         List<Opportunity> opportunities;


### PR DESCRIPTION
I noticed that Test cases (of classes that use Query.cls internally) involving `selectAllFields` fail when new fields/objects and new/updated classes that use these fields/objects are deployed together, as SF doesn't gives read permission to the System admin profile on new fields by default . So the workaround was to first deploy the object file -> give atleast read permission to admin profile on new fields/objects, then deploy code in second iteration.
And `selectAllFields` doesn't delivers what it says to do -> query ALL fields
It seems a misnomer

Thus modifying `selectAllFields` to query all fields of the object.
Introduced new method `selectReadableFields` which explicitly does what it says -> query readable(accessible) fields (which is currently being done by `selectAllFields`)

Used `readable` instead of `accessible` in public methods ,on similar lines as `editable` is used for `updateable`.
Used standalone `isSystemContext` var instead of including it in `FieldSetting`, as it's re-used in `selectAllFields('parentObj')` context as well.