### PR TITLE
Optimize Schema.getGlobalDescribe performance

### DIFF
--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -24,14 +24,14 @@
 public class Query {
     public static final String VERSION = '2.0.0-pre';
     
-    public static Map<String, SObjectType> globalDescribe {
+    private static Map<String, SObjectType> globalDescribe {
         get {
             if (globalDescribe == null) {
                 globalDescribe = Schema.getGlobalDescribe();
             }
             return globalDescribe;
         }
-        private set;
+        set;
     }
 
     /* Public members */

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -23,6 +23,16 @@
  */
 public class Query {
     public static final String VERSION = '2.0.0-pre';
+    
+    public static Map<String, SObjectType> globalDescribe {
+        get {
+            if (globalDescribe == null) {
+                globalDescribe = Schema.getGlobalDescribe();
+            }
+            return globalDescribe;
+        }
+        private set;
+    }
 
     /* Public members */
     public Query(String objectName) {
@@ -31,10 +41,6 @@ public class Query {
 
     public Query(String objectName, String namespace) {
         setNamespace(namespace);
-
-        // Get Schema.SObjectType
-        Map<String, Schema.SObjectType> globalDescribe =
-                Schema.getGlobalDescribe();
 
         this.objectType = globalDescribe.get(appendNamespace(objectName));
 


### PR DESCRIPTION
Calling `Schema.getGlobalDescribe()` is time consuming.
Benchmark done by sfdcfox: [stackexchange question](https://salesforce.stackexchange.com/a/219010/62835) 

This PR uses lazy load for getGlobalDescribe so this method is called only once even if multiple Query instances are created.

