### PR TITLE
Make unit tests pass in Enterprise scratch org

### DIFF
--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -1282,12 +1282,29 @@ public class QueryTest {
 
         Account acc = (Account)new Query('Account').selectAllFields(setting).byId(account.Id).fetch();
         System.assertEquals(acc.Name, 'Account 1');
-
-        Query.FieldSetting settingOne = new Query.FieldSetting();
-        settingOne.isAccessible = true;
-        setting.isCalculated = true;
-        Account acc1 = (Account)new Query('Account').selectAllFields(settingOne).byId(account.Id).fetch();
-        System.assertEquals(acc1.Rating, '1');
+    }
+    @isTest
+    static void isCalculatedFieldSettingAddsCalculatedFields(){
+        Workorder workorder = new Workorder();
+        insert workorder;
+        insert new List<WorkorderLineItem>{
+                new WorkorderLineItem( WorkorderId = workorder.Id),
+                new WorkorderLineItem( WorkorderId = workorder.Id)
+        };
+        Query.FieldSetting accessibleCalculatedFields = new Query.FieldSetting();
+        accessibleCalculatedFields.isAccessible = true;
+        accessibleCalculatedFields.isCalculated = true;
+        Test.startTest();
+        Workorder queriedOrder = (Workorder)new Query('Workorder').
+                selectAllFields(accessibleCalculatedFields).
+                byId(workorder.Id).
+                fetch();
+        Test.stopTest();
+        System.assert(queriedOrder.isSet('LineItemCount'), 'Query.fetch(), when called with a FieldSetting that specifies `isCalculated = true`, should return the calculated field `LineItemCount`.');
+        System.assert(queriedOrder.isSet('SubTotal'), 'Query.fetch(), when called with a FieldSetting that specifies `isCalculated = true`, should return the calculated field `SubTotal`.');
+        System.assert(queriedOrder.isSet('TotalPrice'), 'Query.fetch(), when called with a FieldSetting that specifies `isCalculated = true`, should return the calculated field `TotalPrice`.');
+        System.assertEquals(false, queriedOrder.isSet('WorkOrderNumber'), 'Query.fetch(), when called with a FieldSetting that specifies `isCalculated = true`, should not return the non-calculated field `WorkOrderNumber`.');
+        System.assertEquals(2, queriedOrder.LineItemCount, 'Query.fetch(), when called with a FieldSetting that specifies `isCalculated = true` and an Id for a Workorder that has 2 associated WorkOrderLineItems, should return "2" for the LineItemCount.');
     }
     @isTest
     static void debugTest() {

--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -175,9 +175,9 @@ public class QueryTest {
         List<Account> accounts = new Query('Account').
                                  selectField('Id').
                                  selectFields('Name').
-                                 selectFields('Phone, Sic').
+                                 selectFields('Phone, SicDesc').
                                  selectFields(new List<String>{'NumberOfEmployees', 'Website'}).
-                                 selectFields(new Set<String>{'Fax', 'Site'}).
+                                 selectFields(new Set<String>{'Fax', 'ShippingState'}).
                                  selectAllFields().
                                  run();
 
@@ -520,7 +520,7 @@ public class QueryTest {
                         ),
                         Query.doOr(
                             Query.conditionNull('AccountNumber'),
-                            Query.conditionNotNull('Sic')
+                            Query.conditionNotNull('SicDesc')
                         )
                     )
                 ).
@@ -739,7 +739,7 @@ public class QueryTest {
                     addSubquery(
                         Query.subquery('Opportunities').
                         selectAllFields().
-                        addConditionEq('TotalOpportunityQuantity', 10)
+                        addConditionEq('Amount', 20112.79)
                     ).
                     addSubquery(
                         Query.subquery('Tasks').
@@ -770,11 +770,11 @@ public class QueryTest {
                     ).
                     addSubquery(
                         Query.subquery('Opportunities').
-                        selectFields('Name, CloseDate, TotalOpportunityQuantity').
+                        selectFields('Name, CloseDate, Amount').
                         addCondition(
                             Query.doOr(
-                                Query.conditionIn('TotalOpportunityQuantity',
-                                        new Set<Integer>{10}),
+                                Query.conditionIn('Amount',
+                                        new Set<Decimal>{20112.79}),
                                 Query.conditionEq('Name', 'N/A'),
                                 Query.doAnd(
                                     Query.conditionEq('CloseDate', Date.today().addDays(1)),
@@ -810,11 +810,11 @@ public class QueryTest {
                     ).
                     addSubquery(
                         Query.subquery('Opportunities').
-                        selectFields('Name, CloseDate, TotalOpportunityQuantity').
+                        selectFields('Name, CloseDate, Amount').
                         addCondition(
                             Query.doOr(
-                                Query.conditionIn('TotalOpportunityQuantity',
-                                        new Set<Integer>{10}),
+                                Query.conditionIn('Amount',
+                                        new Set<Decimal>{20112.79}),
                                 Query.conditionEq('Name', 'N/A'),
                                 Query.doAnd(
                                     Query.conditionEq('CloseDate', Date.today().addDays(1)),
@@ -888,13 +888,13 @@ public class QueryTest {
 
         account = (Account) new Query('Account')
             .selectAllFields()
-            .addConditionString('Sic = \'D001\'')
+            .addConditionString('SicDesc = \'Aircraft\'')
             .fetch();
         assertAccount(account);
 
         account = (Account) new Query('Account')
             .selectAllFields()
-            .addConditionString('(AnnualRevenue = NULL AND (Sic IN (\'D001\', \'(D002)\')))')
+            .addConditionString('(AnnualRevenue = NULL AND (SicDesc IN (\'Aircraft\', \'Metal Cans\')))')
             .fetch();
         assertAccount(account); 
         
@@ -1090,7 +1090,7 @@ public class QueryTest {
             AccountId = acc.Id,
             Name = 'New Opportunity',
             CloseDate = Date.today().addDays(3),
-            TotalOpportunityQuantity = 10,
+            Amount = 20112.79,
             StageName = 'New');
         insert opp;
 
@@ -1217,7 +1217,7 @@ public class QueryTest {
             AccountId = acc.Id,
             Name = 'New Opportunity',
             CloseDate = Date.today().addDays(3),
-            TotalOpportunityQuantity = 10,
+            Amount = 20112.79,
             StageName = 'New',
             IsPrivate = false);
         insert opp;
@@ -1259,7 +1259,7 @@ public class QueryTest {
             AccountId = acc1.Id,
             Name = 'New Opportunity',
             CloseDate = Date.today().addDays(3),
-            TotalOpportunityQuantity = 10,
+            Amount = 20112.79,
             StageName = 'New',
             IsPrivate = false);
         insert opp;
@@ -1348,11 +1348,11 @@ public class QueryTest {
         Account acc = new Account();
         acc.Name = 'ABC Ltd';
         acc.Phone = '+61 410 000 000';
-        acc.Sic = 'D001';
+        acc.SicDesc = 'Aircraft';
         acc.NumberOfEmployees = 10;
         acc.Website = 'https://www.samplewebsite.com';
         acc.Fax = '+61 2 0000 0000';
-        acc.Site = 'Sydney';
+        acc.ShippingState = 'Wyoming';
 
         insert acc;
 
@@ -1360,7 +1360,7 @@ public class QueryTest {
         opp.AccountId = acc.Id;
         opp.Name = 'New Opportunity';
         opp.CloseDate = Date.today().addDays(3);
-        opp.TotalOpportunityQuantity = 10;
+        opp.Amount = 20112.79;
         opp.StageName = 'New';
         opp.IsPrivate = false;
 
@@ -1377,17 +1377,17 @@ public class QueryTest {
     static void assertAccount(Account acc) {
         System.assertEquals(acc.Name, 'ABC Ltd');
         System.assertEquals(acc.Phone, '+61 410 000 000');
-        System.assertEquals(acc.Sic, 'D001');
+        System.assertEquals(acc.SicDesc, 'Aircraft');
         System.assertEquals(acc.NumberOfEmployees, 10);
         System.assertEquals(acc.Website, 'https://www.samplewebsite.com');
         System.assertEquals(acc.Fax, '+61 2 0000 0000');
-        System.assertEquals(acc.Site, 'Sydney');
+        System.assertEquals(acc.ShippingState, 'Wyoming');
     }
 
     static void assertOpportunity(Opportunity opp) {
         System.assertEquals(opp.Name, 'New Opportunity');
         System.assertEquals(opp.CloseDate, Date.today().addDays(3));
-        System.assertEquals(opp.TotalOpportunityQuantity, 10);
+        System.assertEquals(opp.Amount, 20112.79);
     }
 
     static void assertTask(Task task) {


### PR DESCRIPTION
- Fix test for `isCalculated` FieldSetting
- Fix tests failing in Enterprise scratch orgs

Addresses #51

- Tested in default Enterprise edition and Developer edition scratch orgs
- Code coverage remains the same, except line 1771 is now also covered
